### PR TITLE
Remove dead link and replace with new link for Git Build Hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Listing a few git resources here for everyone.
 
 - [pre-commit](https://pre-commit.com/) — a framework for managing and maintaining multi-language pre-commit hooks from Yelp. Extensive support for multiple programming language.
 - [Overcommit](https://github.com/brigade/overcommit/) — a extendable Git hook manager written with Ruby.
-- [git-hooks](https://github.com/icefox/git-hooks/) — tool to manage project, user, and global Git hooks
+- [Git Build Hook Maven Plugin](https://github.com/rudikershaw/git-build-hook) — Install Git hooks and configuration in a Maven build.
 - [quickhook](https://github.com/dirk/quickhook/) — a fast, Unix'y, opinionated Git hook runner
 - [husky](https://github.com/typicode/husky) - Git hooks for Node.js, manage your hooks from your package.json
 


### PR DESCRIPTION
IMPROVE

Git Hook management

- Removed a dead link.
- Added a link in it's place to the Git Build Hook Maven plugin.